### PR TITLE
change exception handling for mavcan

### DIFF
--- a/dronecan/driver/__init__.py
+++ b/dronecan/driver/__init__.py
@@ -14,7 +14,7 @@ from .slcan import SLCAN
 try:
     from .mavcan import MAVCAN
     have_mavcan = True
-except ImportError:
+except Exception:
     have_mavcan = False
 from .common import DriverError, CANFrame
 


### PR DESCRIPTION
this was causing AP_Periph to fail to build due to python2 incompatibility