### PR TITLE
Add file interface for recording and replaying CAN data

### DIFF
--- a/dronecan/driver/__init__.py
+++ b/dronecan/driver/__init__.py
@@ -12,6 +12,7 @@ import sys
 from .python_can import PythonCAN
 from .slcan import SLCAN
 from .mcast import mcast
+from .file import file
 try:
     from .mavcan import MAVCAN
     have_mavcan = True
@@ -53,6 +54,12 @@ def make_driver(device_name, **kwargs):
         return SLCAN(device_name[6:], **kwargs)
     elif device_name.startswith("mcast:"):
         return mcast(device_name[6:], **kwargs)
+    elif device_name.startswith("filein:"):
+        kwargs['readonly'] = True
+        return file(device_name[7:], **kwargs)
+    elif device_name.startswith("fileout:"):
+        kwargs['readonly'] = False
+        return file(device_name[8:], **kwargs)
     elif windows_com_port or unix_tty:
         if is_mavlink_port(device_name, **kwargs):
             return MAVCAN(device_name, **kwargs)

--- a/dronecan/driver/common.py
+++ b/dronecan/driver/common.py
@@ -158,5 +158,13 @@ class AbstractDriver(object):
         '''set MAVLink2 signing passphrase'''
         pass
 
+    def stream_progress(self):
+        '''stream progress of the current stream'''
+        pass
+
+    def end_of_stream(self):
+        '''end of stream'''
+        pass
+
     def send(self, message_id, message, extended=False, canfd=False):
         self.send_frame(CANFrame(message_id, message, extended, canfd=canfd))

--- a/dronecan/driver/file.py
+++ b/dronecan/driver/file.py
@@ -1,0 +1,158 @@
+#
+# Copyright (C) 2023 DroneCAN Development Team  <dronecan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+'''
+ driver for reading/writing CAN frames from/to a file
+
+   - MAGIC 0x2934 16 bit
+   - 64 bit monotonic timestamp (microseconds)
+   - 16 bit CRC CRC-16-CCITT (over all bytes after CRC)
+   - 16 bit length
+   - 16 bit flags
+   - 32 bit message ID
+   - data[]
+
+ all data is little endian
+'''
+import os
+import dronecan.dsdl.common as common
+from logging import getLogger
+from .common import DriverError, CANFrame, AbstractDriver
+import struct
+import time
+import dronecan.dsdl.common as common
+
+FILE_MAGIC = 0x2934
+FILE_FLAG_CANFD = 0x0001
+class file(AbstractDriver):
+
+    """
+    Driver for CAN Log File
+    """
+
+    def __init__(self, filename, **kwargs):
+        """
+        :param filename: filename to read/write
+        :param kwargs: see AbstractDriver
+        """
+        super(file, self).__init__()
+        self.filename = filename
+        self.start_file_monotonic_ts = 0
+        # check if read only option selected
+        if kwargs.get('readonly', False):
+            self.readonly = True
+            self.file = open(filename, 'rb')
+            self.curr_frame = None
+            self.start_monotonic_ts = time.monotonic()
+            self.set_first_and_last_timestamp()
+        else:
+            self.readonly = False
+            self.file = open(filename, 'wb')
+            self.file.seek(0, os.SEEK_END)
+        self.first_receive = False
+
+    def close(self):
+        if self.file is not None:
+            self.file.close()
+
+    def __del__(self):
+        self.close()
+
+    def _read_frame(self):
+        # read header
+        header = self.file.read(20)
+        if len(header) < 20:
+            return None, None
+        magic, timestamp, crc, length, flags, msgid = struct.unpack('<HQHHHL', header)
+        timestamp = timestamp/1e6
+        if magic != FILE_MAGIC:
+            raise DriverError("invalid magic")
+        # read data
+        data = self.file.read(length)
+        if len(data) < length:
+            raise DriverError("short read")
+        # calculate CRC
+        crc2 = common.crc16_from_bytes(data)
+        if crc != crc2:
+            raise DriverError("CRC error")
+        # create frame
+        is_extended = (msgid & (1<<31)) != 0
+        is_canfd = flags & FILE_FLAG_CANFD != 0
+        canid = msgid & 0x1FFFFFFF
+        ts_monotonic = self.start_monotonic_ts + timestamp - self.start_file_monotonic_ts
+        frame = CANFrame(canid,data,is_extended,ts_monotonic,canfd=is_canfd)
+        return frame, timestamp
+
+    def set_first_and_last_timestamp(self):
+        # seek to beginning of file
+        self.file.seek(0, os.SEEK_SET)
+        # read first frame
+        frame, timestamp = self._read_frame()
+        if frame is None:
+            raise DriverError("empty file")
+        self.start_file_monotonic_ts = timestamp
+
+        # run through file to find last frame
+        while True:
+            frame, timestamp = self._read_frame()
+            self.end_file_monotonic_ts = timestamp
+            if frame is None:
+                break
+        # seek to start of file
+        self.file.seek(0, os.SEEK_SET)
+
+    def get_start_timestamp(self):
+        return self.start_file_monotonic_ts
+
+    def get_last_timestamp(self):
+        return self.end_file_monotonic_ts
+
+    def set_start_timestamp(self, timestamp):
+        self.start_monotonic_ts = timestamp
+
+    def receive(self, timeout=None):
+        if not self.readonly:
+            return None
+        if self.start_monotonic_ts is None:
+            self.start_monotonic_ts = time.monotonic()
+        if self.curr_frame is None:
+            self.curr_frame, _ = self._read_frame()
+            if self.curr_frame is None:
+                return None
+        if self.curr_frame.ts_monotonic > time.monotonic():
+            if timeout is not None and (self.curr_frame.ts_monotonic - time.monotonic()) <= timeout:
+                # sleep until timeout
+                time.sleep(self.curr_frame.ts_monotonic - time.monotonic())
+            else:
+                return None
+        self.curr_frame.ts_real = time.time()
+        frame = self.curr_frame
+        self.curr_frame = None
+        return frame
+
+    def send_frame(self, frame, timeout=None):
+        if self.readonly:
+            return
+        if self.first_receive is False:
+            self.first_receive = True
+            self.start_file_monotonic_ts = time.monotonic()
+            self.start_monotonic_ts = self.start_file_monotonic_ts
+        # calculate flags
+        flags = 0
+        if frame.canfd:
+            flags |= FILE_FLAG_CANFD
+        # calculate message id
+        msgid = frame.id
+        if frame.extended:
+            msgid |= 1<<31
+        # calculate CRC
+        crc = common.crc16_from_bytes(frame.data)
+        # write header
+        header = struct.pack('<HQHHHL', FILE_MAGIC, int(frame.ts_monotonic*1e6), crc, len(frame.data), flags, msgid)
+        self.file.write(header)
+        # write data
+        self.file.write(frame.data)
+        # flush
+        self.file.flush()

--- a/dronecan/driver/file.py
+++ b/dronecan/driver/file.py
@@ -115,16 +115,18 @@ class file(AbstractDriver):
     def receive(self, timeout=None):
         if not self.readonly:
             return None
+        curr_time = time.monotonic()
         if self.start_monotonic_ts is None:
-            self.start_monotonic_ts = time.monotonic()
+            self.start_monotonic_ts = curr_time
         if self.curr_frame is None:
             self.curr_frame, _ = self._read_frame()
             if self.curr_frame is None:
                 return None
-        if self.curr_frame.ts_monotonic > time.monotonic():
-            if timeout is not None and (self.curr_frame.ts_monotonic - time.monotonic()) <= timeout:
-                # sleep until timeout
-                time.sleep(self.curr_frame.ts_monotonic - time.monotonic())
+        time_to_next_frame = self.curr_frame.ts_monotonic - curr_time
+        if time_to_next_frame > 0:
+            if timeout is not None and time_to_next_frame <= timeout:
+                # sleep until next frame
+                time.sleep(time_to_next_frame)
             else:
                 return None
         self.curr_frame.ts_real = time.time()

--- a/dronecan/driver/file.py
+++ b/dronecan/driver/file.py
@@ -55,6 +55,7 @@ class file(AbstractDriver):
 
     def close(self):
         if self.file is not None:
+            self.file.flush()
             self.file.close()
 
     def __del__(self):
@@ -114,6 +115,8 @@ class file(AbstractDriver):
 
     def receive(self, timeout=None):
         if not self.readonly:
+            if timeout is not None:
+                time.sleep(timeout)
             return None
         curr_time = time.monotonic()
         if self.start_monotonic_ts is None:

--- a/examples/canlog2gps.py
+++ b/examples/canlog2gps.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import dronecan
+import sys
+# progress bar
+from tqdm import tqdm
+
+if len(sys.argv) != 4:
+    print("Usage: python3 canlog2gps.py <messageName> <logfile> <outputfile>")
+    sys.exit(1)
+
+# Create a CAN bus instance
+global node
+print('Starting server as Node ID', 10)
+
+filename = sys.argv[2]
+out_file = open(sys.argv[3],'wb')
+node = dronecan.make_node("filein:"+filename, node_id=10, bitrate=1000000,speedup=-1)
+
+def handle_Data(msg):
+    # dump the message data to a file
+    out_file.write(msg.message.data.to_bytes())
+
+# message type by key name
+message_type = getattr(dronecan.ardupilot.gnss, sys.argv[1])
+node.add_handler(message_type, handle_Data)
+
+# progress bar
+pbar = tqdm(total=100)
+
+while True:
+    try:
+        node.spin(0.001)
+        # print(node.can_driver.stream_progress())
+        # show the progress of the stream
+        pbar.update(node.can_driver.stream_progress() - pbar.n)
+        if node.can_driver.end_of_stream():
+            print('End of stream')
+            out_file.flush()
+            out_file.close()
+            sys.exit(0)
+    except KeyboardInterrupt:
+        out_file.flush()
+        out_file.close()
+        sys.exit(0)


### PR DESCRIPTION
* Allows logging data and replaying it.
Example command:
```
python tools/dronecan_bridge.py vcan0 fileout:log.bin
# publish only messages from nodeid 125
python tools/dronecan_bridge.py vcan0 filein:log.bin --filter-nodeid 125
```