### PR TITLE
use modern standard for python packaging

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install pydronecan
       run: |
-        python setup.py build install
+        python -m pip install .
 
     - name: Run Tests from local
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = [
+    "setuptools",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dronecan"
+dynamic = ["version", "scripts"]
+description = "Python implementation of the DroneCAN protocol stack"
+authors = [{name='Pavel Kirienko', email='uavcan@googlegroups.com'},
+           {name='Ben Dyer', email='ben_dyer@mac.com'}]
+maintainers = [{name='Andrew Tridgell', email='andrew@tridgell.net'},
+               {name='Siddharth Purohit', email='sidbpurohit@gmail.com'}]
+readme = {file = "README.txt", content-type = "text/markdown"}
+requires-python = ">=3.7"
+classifiers = [
+    'Development Status :: 6 - Mature',
+    'Intended Audience :: Developers',
+    'Topic :: Software Development :: Libraries',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python',
+]
+
+[project.urls]
+Homepage = "https://github.com/DroneCAN/pydronecan"
+Issues = "https://github.com/DroneCAN/pydronecan/issues"
+
+[tool.setuptools]
+packages=['dronecan',
+          'dronecan.dsdl',
+          'dronecan.driver',
+          'dronecan.app']

--- a/setup.py
+++ b/setup.py
@@ -24,34 +24,12 @@ try:
     if not os.path.exists('dronecan/dsdl_specs'):
         os.symlink('../../DSDL', 'dronecan/dsdl_specs')
     args = dict(
-        name='dronecan',
         version=__version__,
-        description='Python implementation of the DroneCAN protocol stack',
-        long_description = long_description,
-        long_description_content_type = "text/markdown",
-        packages=[
-            'dronecan',
-            'dronecan.dsdl',
-            'dronecan.driver',
-            'dronecan.app',
-        ],
         package_data={
             'dronecan': [os.path.join(root[len('dronecan/'):], fname)
                     for root, dirs, files in os.walk('dronecan/dsdl_specs', followlinks=True)
                     for fname in files if fname.endswith('.uavcan')]
         },
-        author='Pavel Kirienko, Ben Dyer',
-        author_email='uavcan@googlegroups.com',
-        url='https://dronecan.github.io',
-        license='MIT',
-        classifiers=[
-            'Development Status :: 3 - Alpha',
-            'Intended Audience :: Developers',
-            'Topic :: Software Development :: Libraries',
-            'License :: OSI Approved :: MIT License',
-            'Programming Language :: Python',
-        ],
-        keywords='',
         scripts = [ 'tools/dronecan_bridge.py' ]
     )
     # ensure dsdl specs are not empty


### PR DESCRIPTION
Follows the recomendation presented here and removes the deprecation message for using only setup.py https://packaging.python.org/en/latest/guides/modernize-setup-py-project/