### PR TITLE
Allow overrides in the vendor specific data type DSDL ID range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,3 @@ target/
 
 # history
 .history
-
-# we don't have dsdl in this repo any more
-dsdl/

--- a/dronecan/dsdl/parser.py
+++ b/dronecan/dsdl/parser.py
@@ -866,6 +866,12 @@ def parse_namespaces(source_dirs, search_dirs=None):
             value = all_default_dtid[key]
             first = pretty_filename(value[0])
             second = pretty_filename(filename)
+
+            # Allow overrides for vendor specific data types in the range [20000, 21000)
+            if 20000 <= t.default_dtid < 21000:
+                logger.warning('Overriding previously defined data type: [%s] [%s]', first, second)
+                return
+
             if t.get_dsdl_signature() != value[1].get_dsdl_signature():
                 error('Redefinition of data type ID: [%s] [%s]', first, second)
             else:

--- a/test/dsdl/fake_dsdl/ns0_nonvendor_base/ns0/21000.Type0.uavcan
+++ b/test/dsdl/fake_dsdl/ns0_nonvendor_base/ns0/21000.Type0.uavcan
@@ -1,0 +1,1 @@
+uint8 field0

--- a/test/dsdl/fake_dsdl/ns0_nonvendor_redefined/ns0/21000.Type0.uavcan
+++ b/test/dsdl/fake_dsdl/ns0_nonvendor_redefined/ns0/21000.Type0.uavcan
@@ -1,0 +1,1 @@
+uint16 field0

--- a/test/dsdl/test_parser.py
+++ b/test/dsdl/test_parser.py
@@ -37,15 +37,25 @@ class TestParseNamespaces(unittest.TestCase):
 
     def test_redefinition_in_search_dir(self):
         '''
-        Validate the parser does not allow redefinitions in the search dir
+        Validate that vendor-specific type IDs in [20000, 21000) are allowed to be
+        overridden in the search dir.
         '''
         ns0_dir = '{}/fake_dsdl/ns0_base/ns0'.format(os.path.dirname(__file__))
         ns0_dir_with_redefinition = '{}/fake_dsdl/ns0_redefined/ns0'.format(os.path.dirname(__file__))
-        try:
+
+        parse_namespaces([ns0_dir], [ns0_dir_with_redefinition])
+
+    def test_non_vendor_redefinition_in_search_dir(self):
+        '''
+        Validate the parser does not allow redefinitions with differing signatures for
+        non-vendor type IDs (outside the [20000, 21000) vendor-override range).
+        '''
+        ns0_dir = '{}/fake_dsdl/ns0_nonvendor_base/ns0'.format(os.path.dirname(__file__))
+        ns0_dir_with_redefinition = '{}/fake_dsdl/ns0_nonvendor_redefined/ns0'.format(os.path.dirname(__file__))
+
+        with self.assertRaises(DsdlException) as context:
             parse_namespaces([ns0_dir], [ns0_dir_with_redefinition])
-            self.assertTrue(False) # parse_namespaces should raise an exception, shouldn't get here
-        except DsdlException as e:
-            self.assertTrue(e.args[0].startswith("Redefinition of data type ID"))
+        self.assertTrue(context.exception.args[0].startswith("Redefinition of data type ID"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request allows overriding DSDL definitions with ones that come latest on the path list when in the "Vendor-specific messages types" range indicated at https://dronecan.github.io/Specification/5._Application_level_conventions/. 

With this, I can now add DSDLs with conflicting IDs to my `uavcan_vendor_specific_types` directory and decode the DSDLs as expected (as was the behavior back when we were using UAVCAN V0 when the DSDL repository didn't define anything in the vendor specific range).

I think this is a reasonable approach since there are only ever 999 IDs allocated for Vendors, so the chance of collisions with existing DSDLs is relatively high as new public DSDLs become available. However, I would also be fine with a strategy such as the one called out in https://github.com/dronecan/pydronecan/issues/30 since that would allow me to avoid the conflicting IDs in the first place.