### PR TITLE
Fix TypeError in slcan.py when formatting standard (non-extended) CAN…

### DIFF
--- a/dronecan/driver/slcan.py
+++ b/dronecan/driver/slcan.py
@@ -408,9 +408,9 @@ class TxWorker:
         self._termination_condition = termination_condition
 
     def _send_frame(self, frame):
-        marker = 'D' if frame.canfd else 'T'
+        marker = 'D' if frame.canfd else ('T' if frame.extended else 't')
         dlc_len = CANFrame.datalength_to_dlc(len(frame.data))
-        line = '%s%X%s\r' % (('%c%08X' if frame.extended else 't%03X') % (marker, frame.id),
+        line = '%c%s%X%s\r' % (marker, ('%08X' if frame.extended else '%03X') % (frame.id),
                              dlc_len,
                              binascii.b2a_hex(frame.data).decode('ascii'))
 


### PR DESCRIPTION
Try to fix a type error on the _send_frame function of the slcan.py driver.
I found this bug while using the Jupyter console of the Dronecan GUI app:
<img width="1002" height="632" alt="25-09-2025 12h02m28s" src="https://github.com/user-attachments/assets/87de6ffe-f879-49ed-987a-31ad8f198d5b" />

After some tinkering with the pydronecan module, I've found that the `marker` variable was being put in the wrong place when we try to send a standard frame (11 bit identifier) in the following function of the `TxWorker`:
```python
def _send_frame(self, frame):
        marker = 'D' if frame.canfd else 'T'
        dlc_len = CANFrame.datalength_to_dlc(len(frame.data))
        line = '%s%X%s\r' % (('%c%08X' if frame.extended else 't%03X') % (marker, frame.id),
                             dlc_len,
                             binascii.b2a_hex(frame.data).decode('ascii'))

        self._conn.write(line.encode('ascii'))
        self._conn.flush()
```
