### PR TITLE
driver: Allow pydronecan to set AutoPilot Parameter

### DIFF
--- a/dronecan/driver/common.py
+++ b/dronecan/driver/common.py
@@ -158,6 +158,10 @@ class AbstractDriver(object):
         '''set MAVLink2 signing passphrase'''
         pass
 
+    def set_parameter(self, name, value):
+        '''set parameter on the remote device'''
+        pass
+
     def stream_progress(self):
         '''stream progress of the current stream'''
         pass

--- a/dronecan/driver/mavcan.py
+++ b/dronecan/driver/mavcan.py
@@ -119,6 +119,8 @@ def io_process(url, bus, target_system, baudrate, tx_queue, rx_queue, exit_queue
             nonlocal signing_key
             signing_key = m.data
             conn.setup_signing(signing_key, sign_outgoing=True)
+        elif m.command == "SetParam":
+            conn.param_set_send(m.data[0], m.data[1])
 
     connect()
     enable_can_forward()
@@ -281,6 +283,13 @@ class MAVCAN(AbstractDriver):
     def get_filter_list(self):
         '''get the current filter list'''
         return self.filter_list
+
+    def set_parameter(self, name, value):
+        '''set parameter in the remote air vehicle'''
+        if len(name) > 16:
+            raise DriverError('Parameter name %s too long' % name)
+
+        self.tx_queue.put_nowait(ControlMessage('SetParam', (name, value)))
 
     def passphrase_to_key(self, passphrase):
         '''convert a passphrase to a 32 byte key'''


### PR DESCRIPTION
These changes allow pydronecan to call into pymavlink to set a parameter on the AutoPilot.