### PR TITLE
mavcan: send queued frames without waiting for the receive timeout

### DIFF
--- a/dronecan/driver/mavcan.py
+++ b/dronecan/driver/mavcan.py
@@ -10,6 +10,7 @@
 import os
 import sys
 import time
+import select
 import signal
 import multiprocessing
 from logging import getLogger
@@ -27,6 +28,7 @@ if 'darwin' in sys.platform:
 else:
     RX_QUEUE_SIZE = 1000000
 TX_QUEUE_SIZE = 1000
+CAN_TYPES = ['CAN_FRAME', 'CANFD_FRAME']
 
 logger = getLogger(__name__)
 kill_process = False
@@ -52,6 +54,21 @@ class ControlMessage(object):
     def __init__(self, command, data):
         self.command = command
         self.data = data
+
+
+def tx_wait_fd(tx_queue):
+    '''fd that becomes readable when a frame is queued for transmit.
+
+    Returns None where it cannot be used, in which case the IO loop
+    falls back to waiting on the link alone. select() on Windows only
+    accepts sockets, so the link and the queue cannot be waited on
+    together there.'''
+    if sys.platform.startswith('win'):
+        return None
+    try:
+        return tx_queue._reader.fileno()
+    except Exception:
+        return None
 
 def io_process(url, bus, target_system, baudrate, tx_queue, rx_queue, exit_queue, parent_pid):
     # leave Ctrl-C (SIGINT) handling to the parent process; this daemon
@@ -146,6 +163,15 @@ def io_process(url, bus, target_system, baudrate, tx_queue, rx_queue, exit_queue
     connect()
     enable_can_forward()
 
+    tx_fd = tx_wait_fd(tx_queue)
+
+    def wait_set():
+        '''fds to wait on, or None to fall back to a blocking receive.
+        Recomputed each pass because reconnect() replaces conn.'''
+        if tx_fd is None or conn.fd is None:
+            return None
+        return [conn.fd, tx_fd]
+
     while True:
         if (not exit_queue.empty() and exit_queue.get() == "QUIT") or exit_proc:
             conn.close()
@@ -193,8 +219,22 @@ def io_process(url, bus, target_system, baudrate, tx_queue, rx_queue, exit_queue
             if time.time() - last_enable > 1:
                 enable_can_forward()
 
+        wait_fds = wait_set()
         try:
-            m = conn.recv_match(type=['CAN_FRAME','CANFD_FRAME'],blocking=True,timeout=0.005)
+            if wait_fds is None:
+                m = conn.recv_match(type=CAN_TYPES, blocking=True, timeout=0.005)
+            else:
+                # Wait on the link and the transmit queue together. A
+                # blocking receive here would hold a frame queued just
+                # after the drain above until the receive times out,
+                # putting milliseconds of latency on every frame we
+                # send. Take anything already parsed first, since the
+                # link fd is not readable while a decoded message sits
+                # in the connection's own buffer.
+                m = conn.recv_match(type=CAN_TYPES, blocking=False)
+                if m is None:
+                    select.select(wait_fds, [], [], 0.005)
+                    m = conn.recv_match(type=CAN_TYPES, blocking=False)
         except Exception as ex:
             reconnect()
             continue


### PR DESCRIPTION
The MAVCAN IO process drains the transmit queue and then blocks in
`recv_match(..., timeout=0.005)`. A frame handed to `send_frame()` just
after that drain sits in the queue until the receive times out, or until
an incoming packet happens to wake the loop. Every outgoing frame picks
up latency that has nothing to do with the link.

This waits on the link and the transmit queue together with `select()`,
so a queued frame wakes the loop immediately.

Details:

* Anything already parsed is taken before selecting. The link fd is not
  readable while a decoded message is sitting in the connection's own
  buffer, so selecting first would stall a ready message for the full
  timeout.
* `wait_set()` is recomputed each pass because `reconnect()` replaces
  `conn`.
* Windows keeps the previous blocking receive. `select()` there only
  accepts sockets, so a serial handle and the queue's pipe cannot be
  waited on together. `tx_wait_fd()` returns `None` in that case, and
  also if the queue does not expose a readable fd, so the fallback is
  taken rather than the change being conditional on the platform at the
  call site.

Measured on a CUAV-X25 forwarding to an AM32 ESC over `mavcan:`, with a
200 Hz `esc.RawCommand` stream out and ~300 frames/s of telemetry back.
The figure is the pure delay between the commanded throttle and the
ESC's own reported view of its input, extracted from a 0.5-20 Hz chirp
(it is flat in milliseconds across the whole sweep, and the fitted line
passes through the origin, so it is a transport delay rather than any
part of the ESC's response):

| | delay |
|---|---|
| before | 10.9 ms |
| after | 9.4 ms |

The gain is smaller than the 5 ms timeout suggests because at ~300
frames/s inbound the blocking receive usually returns early anyway; this
removes the residual wait.

For reference on where the rest of that 9.4 ms lives: the
`multiprocessing.Queue` handoff to the IO process measures 0.30 ms
median (p90 0.87 ms) at 200 Hz, so it is not worth replacing. The
remainder is the MAVLink/USB link and the autopilot's inbound handling,
which schedules `CAN_FRAME` dispatch from `GCS::update_receive` at
300 Hz.
